### PR TITLE
task-7

### DIFF
--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+package-lock.json
+.serverless
+.env

--- a/authorization-service/.npmignore
+++ b/authorization-service/.npmignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "lmbd1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.83",
+    "@types/node": "^16.7.1",
+    "serverless-dotenv-plugin": "^3.9.0",
+    "ts-loader": "^9.2.5",
+    "typescript": "^4.3.5",
+    "webpack": "^5.51.1",
+    "webpack-cli": "^4.8.0"
+  },
+  "scripts": {
+    "deploy": "sls deploy",
+    "build": "webpack --mode=production",
+    "build-deploy": "npm run build && npm run deploy"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/authorization-service/readme.md
+++ b/authorization-service/readme.md
@@ -1,0 +1,1 @@
+RSS-AWS-BE

--- a/authorization-service/serverless.yml
+++ b/authorization-service/serverless.yml
@@ -1,0 +1,28 @@
+service: authorization-service
+
+frameworkVersion: "2"
+
+plugins:
+  - serverless-dotenv-plugin
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  lambdaHashingVersion: 20201221
+  stage: dev
+  region: eu-west-1
+
+package:
+  individually: true
+  patterns:
+    - "!**"
+    - "./dist"
+
+functions:
+  basicAuthorizer:
+    handler: dist/basicAuthorizer.basicAuthorizer
+    package:
+      patterns:
+        - "!dist/**"
+        - "dist/basicAuthorizer.js"
+

--- a/authorization-service/src/lambdas/basicAuthorizer.lambda.ts
+++ b/authorization-service/src/lambdas/basicAuthorizer.lambda.ts
@@ -1,0 +1,9 @@
+"use strict";
+
+import { AuthService } from "../services/products.service";
+
+const authService = new AuthService();
+
+module.exports.basicAuthorizer = async (event, _, callback) => {
+  return authService.tokenAuth(event, _, callback);
+};

--- a/authorization-service/src/services/products.service.ts
+++ b/authorization-service/src/services/products.service.ts
@@ -1,0 +1,59 @@
+export class AuthService {
+  public tokenAuth(event, _, callback) {
+    
+    if (event.type !== 'TOKEN') callback('Unauthorized');
+
+    try {
+      const creds = this.getCreds(event.authorizationToken);
+      const principalId = this.encodeTokent(event.authorizationToken);
+      const effect = this.getEffetcByCreds(creds);
+      const policy = this.generatePolicy(principalId, event.methodArn, effect);
+  
+      callback(null, policy);
+    } catch (error) {
+      callback(`Unauthorized: ${error.message}`);
+    }
+  }
+
+  private generatePolicy(principalId, resource, effect) {
+    return {
+      principalId,
+      policyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Action: 'execute-api:Invoke',
+            Effect: effect,
+            Resource: resource
+          }
+        ]
+      }
+    }
+  }
+
+  private getCreds(token: string): { username: string, password: string } {
+    const encodedToken = this.encodeTokent(token);
+    const buffer = Buffer.from(encodedToken, 'base64');
+    const plainToken = buffer.toString('utf-8').split(':');
+
+    return {
+      username: plainToken[0],
+      password: plainToken[1],
+    }
+  }
+
+  private getEffetcByCreds(creds: { username: string, password: string }): 'Deny' | 'Allow' {
+    const storedUsername = process.env[creds.username];
+    const storedPassword = process.env.TEST_PASSWORD;
+    const isCorrectCreds = storedPassword
+      && storedUsername
+      && storedPassword === creds.password
+      && storedUsername === creds.username;
+
+    return isCorrectCreds ? 'Allow' : 'Deny';
+  }
+
+  private encodeTokent(token: string): string {
+    return token.split(' ')[1];
+  }
+}

--- a/authorization-service/tsconfig.json
+++ b/authorization-service/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "declaration": false,
+        "removeComments": true,
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "allowSyntheticDefaultImports": true,
+        "target": "es2017",
+        "sourceMap": false,
+        "outDir": "./dist",
+        "baseUrl": "./",
+        "incremental": false,
+        "skipLibCheck": true
+    }
+}

--- a/authorization-service/webpack.config.js
+++ b/authorization-service/webpack.config.js
@@ -1,0 +1,59 @@
+const webpack = require('webpack');
+const path = require('path');
+const fs = require('fs');
+const lambdasDir = path.join(__dirname, 'src/lambdas');
+
+module.exports = {
+  context: __dirname,
+  entry: findLambdaFilesPath(),
+  resolve: {
+    extensions: ['.js', '.ts', '.json'],
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, 'dist'),
+    filename: '[name].js',
+  },
+  target: 'node',
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'ts-loader',
+        exclude: [
+          [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(__dirname, '.serverless'),
+            path.resolve(__dirname, 'swagger'),
+          ],
+        ]
+      },
+    ],
+  },
+  plugins: [
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^pg-native$/,
+    }),
+  ]
+};
+
+function findLambdaFilesPath() {
+  const filesName = fs.readdirSync(lambdasDir);
+
+  return filesName
+    .filter(fileName => fileName.includes('.lambda.ts'))
+    .map(mapFileObjectInfo)
+    .reduce(reduceEntryFilesInfo, {})
+}
+
+function mapFileObjectInfo(fileName) {
+  return {
+    name: fileName.split('.')[0],
+    path: `./src/lambdas/${fileName}`
+  }
+}
+
+function reduceEntryFilesInfo(entry, file) {
+  entry[file.name] = file.path;
+  return entry;
+}

--- a/import-service/serverless.yml
+++ b/import-service/serverless.yml
@@ -62,6 +62,16 @@ resources:
               - '<'
               - 100
 
+    GatewayResponseDefault4XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_4XX
+        RestApiId:
+          Ref: 'ApiGatewayRestApi'
+
 package:
   individually: true
   patterns:
@@ -83,11 +93,19 @@ functions:
             parameters:
               querystrings:
                 name: true
-          cors:
-            origin: "*"
-            headers:
-              - Content-Type
-            allowCredentials: false
+          cors: true
+          authorizer:
+            name: tokenAuthorizer
+            arn:
+              !Join
+                - ':'
+                - - 'arn:aws:lambda'
+                  - !Ref AWS::Region
+                  - !Ref AWS::AccountId
+                  - 'function:authorization-service-dev-basicAuthorizer'
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Authorization
+            type: token
 
   importFileParser:
       handler: dist/importFileParser.importFileParser


### PR DESCRIPTION
Выполнены задания:
1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
2 - import-service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
3 - update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token')
4 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file

Запрос для importProductsFile: https://uevyoxihci.execute-api.eu-west-1.amazonaws.com/dev/import

**При открытии клиента упадет ошибка 403, не пугаться, это из-за того, что я выключил бд.**


Ссылка на [клиент](https://d3ledi3ijgqxmj.cloudfront.net/). Для проверки клиента можно использовать `localStorage.setItem('authorization_token', 'Burach0k:TEST_PASSWORD');` в консоли
Ссылка на [PR ](https://github.com/Burach0k/rss-aws-fe/pull/4) клиента 

Итог: 6 баллов
